### PR TITLE
Add self-managed gitlab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CI Demon currently supports the following CI providers:
 - Github Checks
 - CircleCI
 - TravisCI
-- Gitlab (cloud service)
+- Gitlab SaaS & self-managed
 - AppCenter
 - Bitrise
 
@@ -47,9 +47,9 @@ CI Demon can also create http ping checks for you to make sure your deployment i
 - Not a SaaS, it's a native macOS app
 - Filter branches/builds by Regex
 - Trigger rebuilds for builds
-- Track github PRs and/or branches
+- Track Github PRs and/or branches
 - Natively share a job to your team mates
-
+- Filter Gitlab projects by visibility settings 
 ## License
 
 MIT License

--- a/src/container/AddToken.container.tsx
+++ b/src/container/AddToken.container.tsx
@@ -55,6 +55,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
       root.ui.addToast({
         text: 'Please add a name',
         type: 'error',
+        position: 'top',
       });
       return;
     }
@@ -63,6 +64,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
       root.ui.addToast({
         text: 'Please add a key',
         type: 'error',
+        position: 'top',
       });
       return;
     }
@@ -72,6 +74,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
         root.ui.addToast({
           text: 'Please add a valid base URL',
           type: 'error',
+          position: 'top',
         });
         return;
       }

--- a/src/container/AddToken.container.tsx
+++ b/src/container/AddToken.container.tsx
@@ -14,7 +14,7 @@ import {observer} from 'mobx-react-lite';
 import {useStore} from 'Root.store';
 import {IRootStackParams} from 'Route';
 import {tw} from 'tailwind';
-import {useDarkTheme, useDynamic} from 'lib';
+import {useDarkTheme, useDynamic, REGEX_VALID_URL} from 'lib';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 interface IProps {
@@ -34,7 +34,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
   let [source, setSource] = useState<Source>(`CircleCI`);
   let [name, setName] = useState(``);
   let [key, setKey] = useState(``);
-  let [baseURL, setBaseURL] = useState(`gitlab.com`);
+  let [baseURL, setBaseURL] = useState(`https://gitlab.com`);
   let [visibility, setVisibility] = useState<GitlabVisibility>(`private`);
   let secondField = useRef<TextInput>();
   let thirdField = useRef<TextInput>();
@@ -68,9 +68,9 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
     }
 
     if (isGitlab) {
-      if(!baseURL){
+      if(!(baseURL && REGEX_VALID_URL.test(baseURL))){
         root.ui.addToast({
-          text: 'Please add a base URL',
+          text: 'Please add a valid base URL',
           type: 'error',
         });
         return;
@@ -152,7 +152,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
             <Text style={tw(`py-3 text-xs font-light`)}>HOST DOMAIN</Text>
 
             <Text style={tw(`pb-3 text-xs`)}>
-            {`You can replace gitlab.com below with your own instance domain if you are using a self-managed Gitlab instance.`}
+            {`You can replace https://gitlab.com below with your own instance domain if you are using a self-managed Gitlab instance.`}
             </Text>
 
             <TextInput
@@ -163,7 +163,7 @@ export const AddTokenContainer = observer(({navigation}: IProps) => {
                 },
                 `w-full px-3 py-2 bg-opacity-70 rounded-lg`,
               )}
-              placeholder="gitlab.com"
+              placeholder="https://gitlab.com"
               value={baseURL}
               onChangeText={setBaseURL}
               //@ts-ignore

--- a/src/container/Toast.container.tsx
+++ b/src/container/Toast.container.tsx
@@ -20,7 +20,7 @@ export const ToastContainer = observer(() => {
     <View
       style={[
         tw(`absolute p-4 rounded`),
-        {bottom: 20, left: 20, right: 20},
+        {...(latestToast.position === 'top' ? {top: 20} : {bottom: 20}), left: 20, right: 20},
         conditionalStyle,
       ]}>
       <Text style={tw(`text-white`)}>{latestToast.text}</Text>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,3 +4,40 @@ export let TINT_MAPPING: Record<Status, any> = {
   running: `#FFBE30`,
   pending: {dynamic: {light: `#37474F`, dark: `#DDD`}},
 }
+export let REGEX_VALID_URL = new RegExp(
+  "^" +
+    // protocol identifier
+    "(?:(?:https?|ftp)://)" +
+    // user:pass authentication
+    "(?:\\S+(?::\\S*)?@)?" +
+    "(?:" +
+    // IP address exclusion
+    // private & local networks
+    "(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
+    "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
+    "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
+    // IP address dotted notation octets
+    // excludes loopback network 0.0.0.0
+    // excludes reserved space >= 224.0.0.0
+    // excludes network & broacast addresses
+    // (first & last IP address of each class)
+    "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+    "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+    "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+    "|" +
+    // host name
+    "(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)" +
+    // domain name
+    "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*" +
+    // TLD identifier
+    "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" +
+    // TLD may end with dot
+    "\\.?" +
+    ")" +
+    // port number
+    "(?::\\d{2,5})?" +
+    // resource path
+    "(?:[/?#]\\S*)?" +
+    "$",
+  "i"
+);

--- a/src/store/Api.store.ts
+++ b/src/store/Api.store.ts
@@ -477,6 +477,8 @@ export let createApiStore = (root: IRootStore) => {
     },
 
     fetchGitlabNodes: async (
+      baseURL: string,
+      visibility: GitlabVisibility,
       key: string,
       options: IFetchOptions,
     ): Promise<INode[]> => {
@@ -488,7 +490,7 @@ export let createApiStore = (root: IRootStore) => {
         let idAfter: string | null = null;
 
         while (shouldFetchProjects) {
-          let url = `https://gitlab.com/api/v4/projects?visibility=private&pagination=keyset&simple=true&per_page=100&order_by=id&sort=asc`;
+          let url = `https://${baseURL}/api/v4/projects?${visibility ? `visibility=${visibility}&` : ``}pagination=keyset&simple=true&per_page=100&order_by=id&sort=asc`;
           if (!!idAfter) {
             url += `&id_after=${idAfter}`;
           }
@@ -499,7 +501,6 @@ export let createApiStore = (root: IRootStore) => {
               Authorization: `Bearer ${key}`,
             },
           });
-
           if (projectBatch.length === 0) {
             shouldFetchProjects = false;
           } else {
@@ -510,7 +511,7 @@ export let createApiStore = (root: IRootStore) => {
 
         let pipelines: Promise<GitlabPipelineDto[]>[] = projects.map((p) =>
           get({
-            url: `https://gitlab.com/api/v4/projects/${p.id}/pipelines?per_page=100`,
+            url: `https://${baseURL}/api/v4/projects/${p.id}/pipelines?per_page=100`,
             headers: {
               Authorization: `Bearer ${key}`,
             },

--- a/src/store/Api.store.ts
+++ b/src/store/Api.store.ts
@@ -490,7 +490,7 @@ export let createApiStore = (root: IRootStore) => {
         let idAfter: string | null = null;
 
         while (shouldFetchProjects) {
-          let url = `https://${baseURL}/api/v4/projects?${visibility ? `visibility=${visibility}&` : ``}pagination=keyset&simple=true&per_page=100&order_by=id&sort=asc`;
+          let url = `${baseURL}/api/v4/projects?${visibility ? `visibility=${visibility}&` : ``}pagination=keyset&simple=true&per_page=100&order_by=id&sort=asc`;
           if (!!idAfter) {
             url += `&id_after=${idAfter}`;
           }
@@ -511,7 +511,7 @@ export let createApiStore = (root: IRootStore) => {
 
         let pipelines: Promise<GitlabPipelineDto[]>[] = projects.map((p) =>
           get({
-            url: `https://${baseURL}/api/v4/projects/${p.id}/pipelines?per_page=100`,
+            url: `${baseURL}/api/v4/projects/${p.id}/pipelines?per_page=100`,
             headers: {
               Authorization: `Bearer ${key}`,
             },

--- a/src/store/Node.store.test.ts
+++ b/src/store/Node.store.test.ts
@@ -258,12 +258,14 @@ describe(`NodeStore`, () => {
   it(`fetch Gitlab nodes`, async (done) => {
     let name = `Gitlab key`;
     let token = `123456789`;
+    let baseURL = `gitlab.com`;
+    let visibility: GitlabVisibility = `private`;
 
     let fakeNode: INode = {
       id: 'some random node id',
       url: 'random url',
       date: 'latest date',
-      source: `CircleCI`,
+      source: `Gitlab`,
       label: `fake label`,
       status: `passed`,
     };
@@ -272,9 +274,9 @@ describe(`NodeStore`, () => {
       return Promise.resolve([fakeNode]);
     });
 
-    nodeStore.addToken(`Gitlab`, name, token);
+    nodeStore.addToken(`Gitlab`, name, token, baseURL, visibility);
 
-    expect(ROOT_MOCK.api.fetchGitlabNodes).toHaveBeenCalledWith(token, {
+    expect(ROOT_MOCK.api.fetchGitlabNodes).toHaveBeenCalledWith(baseURL, visibility, token, {
       showBuildNumber: false,
     });
 

--- a/src/store/Node.store.test.ts
+++ b/src/store/Node.store.test.ts
@@ -258,7 +258,7 @@ describe(`NodeStore`, () => {
   it(`fetch Gitlab nodes`, async (done) => {
     let name = `Gitlab key`;
     let token = `123456789`;
-    let baseURL = `gitlab.com`;
+    let baseURL = `https://gitlab.com`;
     let visibility: GitlabVisibility = `private`;
 
     let fakeNode: INode = {

--- a/src/store/Node.store.ts
+++ b/src/store/Node.store.ts
@@ -286,7 +286,7 @@ export async function createNodeStore(root: IRootStore) {
               return root.api.fetchBitriseNodes(t.key, fetchOptions);
 
             case `Gitlab`:
-              return root.api.fetchGitlabNodes(t.key, fetchOptions);
+              return root.api.fetchGitlabNodes(t.baseURL!, t.visibility!, t.key, fetchOptions);
 
             default:
               break;
@@ -395,10 +395,11 @@ export async function createNodeStore(root: IRootStore) {
         }
       },
 
-      addToken: (source: Source, name: string, key: string) => {
+      addToken: (source: Source, name: string, key: string, baseURL?: string, visibility?: GitlabVisibility ) => {
         let token: IToken = {
           source,
           name,
+          ...(source === 'Gitlab' ? { baseURL, visibility } : {}),
           key,
         };
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -53,9 +53,13 @@ declare type Status = `pending` | `passed` | `running` | `failed`;
 
 declare type VCS = `github` | `bitbucket` | `gitlab` | `unknown`;
 
+declare type GitlabVisibility = `public` | `internal` | `private` | null;
+
 declare interface IToken {
   source: Source;
   name: string;
+  baseURL?: string | null;
+  visibility?: GitlabVisibility;
   key: string;
 }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -97,6 +97,7 @@ declare interface INode {
 declare interface IToast {
   text: string;
   type: `success` | `error` | `neutral`;
+  position?: `top` | `bottom`;
 }
 
 declare interface IPingTestDto {


### PR DESCRIPTION
Closes #1 

Added a base url option as discussed in the issue but also a visibility one to allow checking public or internal repos since it may be more relevant for self-hosted gitlab instances to also have access to the public repos info.

Feel free to review the PR and request changes in the wording or the code!